### PR TITLE
feat(training): route identity + countries-of-concern tags through the kernel (closes #40)

### DIFF
--- a/internal/evidence/provider.go
+++ b/internal/evidence/provider.go
@@ -123,3 +123,71 @@ func (appraiser) Appraise(_ context.Context, in asp.AppraiseIn) (asp.Verdict, er
 // Exposed so the single tag-writing chokepoint in the training service can filter
 // on it without re-deriving the namespace.
 func IsAttestTag(key string) bool { return strings.HasPrefix(key, "attest:") }
+
+// --- attributes provider: identity & countries-of-concern -------------------
+//
+// SetIdentityTags (attest:lab-id, attest:admin-level) and RecordCountryCheck
+// (attest:country, attest:coc-check-current, attest:coc-check-expiry) are direct
+// attestations of recorded facts — there is no quiz to pass. They route through
+// the kernel for the SAME reason training does (one lowering path; a freshness-
+// bound, appraised assertion rather than a hand-built tag set), but the appraiser
+// always passes: the verdict is "these recorded attributes are attested as of
+// now", and the claims are the attest:* tags to write.
+
+// AttrID keys the attributes pair in the registry. Distinct from the training
+// ID so a single registry could hold both, and so the kernel's synthetic markers
+// read "attrs.*" rather than "training.*".
+const AttrID term.ASPID = "attrs"
+
+// Tag is a pre-resolved attest:* attribute to attest. Key is the full IAM tag key
+// (e.g. "attest:lab-id"), sourced from the caller (tags.go constants) so this
+// package never types an attest:* literal — same drift guard as the training pair.
+type Tag struct {
+	Key   string
+	Value string
+}
+
+// AttributesInput is the set of attest:* tags to attest for a principal.
+type AttributesInput struct {
+	Tags []Tag `json:"tags"`
+}
+
+// AttributesProvider assembles the attributes pair from an injected tag set.
+func AttributesProvider(in AttributesInput) asp.Provider {
+	return asp.Provider{
+		ID:        AttrID,
+		Measurer:  attrMeasurer{in: in},
+		Appraiser: attrAppraiser{},
+	}
+}
+
+type attrMeasurer struct{ in AttributesInput }
+
+func (m attrMeasurer) Measure(_ context.Context, _ asp.MeasureIn) (ev.Measurement, error) {
+	if len(m.in.Tags) == 0 {
+		// Nothing to attest — the kernel-native form of "no tags to write".
+		return ev.Measurement{Status: ev.NotApplicable, Detail: "no attributes to attest"}, nil
+	}
+	payload, err := json.Marshal(m.in)
+	if err != nil {
+		return ev.Measurement{}, fmt.Errorf("qualify: marshal attributes: %w", err)
+	}
+	return ev.Measurement{Payload: payload, Status: ev.Collected}, nil
+}
+
+type attrAppraiser struct{}
+
+func (attrAppraiser) Appraise(_ context.Context, in asp.AppraiseIn) (asp.Verdict, error) {
+	var p AttributesInput
+	if err := json.Unmarshal(in.Meas.Payload, &p); err != nil {
+		return asp.Verdict{}, fmt.Errorf("qualify: decode attributes: %w", err)
+	}
+	// No pass/fail: these are recorded facts being attested. Emit each as a claim;
+	// types default to "string" in lowering, which is correct for lab-id, country,
+	// admin-level, RFC3339 expiry; coc-check-current is the string "true".
+	claims := make([]asp.Claim, 0, len(p.Tags))
+	for _, t := range p.Tags {
+		claims = append(claims, asp.Claim{Key: t.Key, Value: t.Value, Type: "string"})
+	}
+	return asp.Verdict{Pass: true, Claims: claims, Reason: "attributes attested"}, nil
+}

--- a/internal/evidence/provider_test.go
+++ b/internal/evidence/provider_test.go
@@ -156,3 +156,81 @@ func TestProvider_FreshnessNonceMismatch(t *testing.T) {
 		t.Fatal("expected freshness failure on nonce mismatch")
 	}
 }
+
+// appraiseAttrs runs the attributes (identity / coc) pair through a CVM and
+// returns the lowered attributes — the same path SetIdentityTags/RecordCountryCheck drive.
+func appraiseAttrs(t *testing.T, in qualifyasp.AttributesInput) map[string]lower.Attr {
+	t.Helper()
+	reg := asp.NewRegistry()
+	if err := reg.Register(qualifyasp.AttributesProvider(in)); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	am, err := qualifyasp.NewEphemeralAM()
+	if err != nil {
+		t.Fatalf("am: %v", err)
+	}
+	c := cvm.New(reg, am, am, nil)
+	protocol := term.Seq(
+		term.Nonce(),
+		term.Seq(term.Meas(term.Self, qualifyasp.AttrID, qualifyasp.Target("arn:aws:iam::123456789012:role/r"), term.Params{}), term.Sig()),
+	)
+	bundle, ch, err := c.Run(context.Background(), protocol)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	v, err := c.Appraise(context.Background(), bundle, ch)
+	if err != nil {
+		t.Fatalf("appraise: %v", err)
+	}
+	if !v.Pass {
+		t.Fatalf("attributes pair must always pass, reason: %s", v.Reason)
+	}
+	return lower.ToAttributes(v)
+}
+
+func TestAttributesProvider_EmitsTagsVerbatim(t *testing.T) {
+	attrs := appraiseAttrs(t, qualifyasp.AttributesInput{Tags: []qualifyasp.Tag{
+		{Key: "attest:lab-id", Value: "genomics-lab"},
+		{Key: "attest:admin-level", Value: "env"},
+	}})
+	if attrs["attest:lab-id"].Value != "genomics-lab" {
+		t.Errorf("attest:lab-id = %q, want genomics-lab", attrs["attest:lab-id"].Value)
+	}
+	if attrs["attest:admin-level"].Value != "env" {
+		t.Errorf("attest:admin-level = %q, want env", attrs["attest:admin-level"].Value)
+	}
+	// Only the two attest:* keys plus the synthetic "attested".
+	attestKeys := 0
+	for k := range attrs {
+		if qualifyasp.IsAttestTag(k) {
+			attestKeys++
+		}
+	}
+	if attestKeys != 2 {
+		t.Errorf("expected 2 attest:* attrs, got %d: %v", attestKeys, attrs)
+	}
+}
+
+func TestAttributesProvider_EmptyIsNotApplicable(t *testing.T) {
+	reg := asp.NewRegistry()
+	if err := reg.Register(qualifyasp.AttributesProvider(qualifyasp.AttributesInput{})); err != nil {
+		t.Fatal(err)
+	}
+	am, _ := qualifyasp.NewEphemeralAM()
+	c := cvm.New(reg, am, am, nil)
+	protocol := term.Seq(term.Nonce(), term.Seq(term.Meas(term.Self, qualifyasp.AttrID, qualifyasp.Target("x"), term.Params{}), term.Sig()))
+	bundle, ch, err := c.Run(context.Background(), protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := c.Appraise(context.Background(), bundle, ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := lower.ToAttributes(v)
+	for k := range attrs {
+		if qualifyasp.IsAttestTag(k) {
+			t.Errorf("NotApplicable must emit no attest:* claims, got %q", k)
+		}
+	}
+}

--- a/internal/training/country_check_test.go
+++ b/internal/training/country_check_test.go
@@ -136,6 +136,42 @@ func TestRecordCountryCheck_WritesIAMTags(t *testing.T) {
 	}
 }
 
+func TestSetIdentityTags_WritesIAMTags(t *testing.T) {
+	svc, mock := newMockService(t)
+	expectRoleARN(mock, "arn:aws:iam::123456789012:role/ResearchRole")
+
+	tagger := &mockTagger{}
+	svc.iamTagger = tagger
+
+	if err := svc.SetIdentityTags(context.Background(), "user-1", "genomics-lab", "env"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Identity tags now flow through the evidence kernel (attributes provider) and
+	// the same tagsFromAttrs chokepoint — the written tags must be unchanged.
+	if tagger.roleName != "ResearchRole" {
+		t.Errorf("role name: got %q, want ResearchRole", tagger.roleName)
+	}
+	if tagger.tags[TagLabID] != "genomics-lab" {
+		t.Errorf("%s: got %q, want genomics-lab", TagLabID, tagger.tags[TagLabID])
+	}
+	if tagger.tags[TagAdminLevel] != "env" {
+		t.Errorf("%s: got %q, want env", TagAdminLevel, tagger.tags[TagAdminLevel])
+	}
+	// No stray tags (e.g. the synthetic "attested" must not leak as an IAM tag).
+	if len(tagger.tags) != 2 {
+		t.Errorf("expected exactly 2 tags, got %d: %v", len(tagger.tags), tagger.tags)
+	}
+}
+
+func TestSetIdentityTags_RejectsInvalidAdminLevel(t *testing.T) {
+	svc, _ := newMockService(t)
+	svc.iamTagger = &mockTagger{}
+	if err := svc.SetIdentityTags(context.Background(), "user-1", "lab", "superuser"); err == nil {
+		t.Error("expected error for invalid admin-level")
+	}
+}
+
 // ── TagForModule / ModuleIDs ───────────────────────────────────────────────
 
 func TestTagForModule(t *testing.T) {

--- a/internal/training/service.go
+++ b/internal/training/service.go
@@ -399,38 +399,53 @@ func (s *Service) writeAttestTags(ctx context.Context, roleARN, moduleID string,
 		ExpiresAt:    expiresAt.Format(time.RFC3339),
 	}
 
+	tags, err := runProviderToTags(ctx, qualifyasp.ID, qualifyasp.Provider(input), qualifyasp.Target(roleARN))
+	if err != nil {
+		return err
+	}
+	if len(tags) == 0 {
+		// Unmapped module or failing score — nothing to write.
+		return nil
+	}
+	return s.tagRole(ctx, roleARN, tags)
+}
+
+// runProviderToTags runs the canonical Seq(Nonce, Seq(Meas, Sig)) term for a
+// single (ASP, appraiser) pair through an ephemeral-AM CVM, appraises the bundle,
+// and lowers the verdict to the attest:* IAM tags. It is the shared kernel path
+// behind both the training and the attributes (identity / countries-of-concern)
+// tag writes.
+func runProviderToTags(ctx context.Context, id term.ASPID, provider asp.Provider, target term.Target) ([]iamtypes.Tag, error) {
 	reg := asp.NewRegistry()
-	if err := reg.Register(qualifyasp.Provider(input)); err != nil {
-		return fmt.Errorf("register training provider: %w", err)
+	if err := reg.Register(provider); err != nil {
+		return nil, fmt.Errorf("register %s provider: %w", id, err)
 	}
 	am, err := qualifyasp.NewEphemeralAM()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	c := cvm.New(reg, am, am, nil)
 
 	protocol := term.Seq(
 		term.Nonce(),
 		term.Seq(
-			term.Meas(term.Self, qualifyasp.ID, qualifyasp.Target(roleARN), term.Params{}),
+			term.Meas(term.Self, id, target, term.Params{}),
 			term.Sig(),
 		),
 	)
 	bundle, ch, err := c.Run(ctx, protocol)
 	if err != nil {
-		return fmt.Errorf("run attestation: %w", err)
+		return nil, fmt.Errorf("run attestation: %w", err)
 	}
 	verdict, err := c.Appraise(ctx, bundle, ch)
 	if err != nil {
-		return fmt.Errorf("appraise: %w", err)
+		return nil, fmt.Errorf("appraise: %w", err)
 	}
+	return tagsFromAttrs(lower.ToAttributes(verdict)), nil
+}
 
-	tags := tagsFromAttrs(lower.ToAttributes(verdict))
-	if len(tags) == 0 {
-		// Unmapped module or failing score — nothing to write.
-		return nil
-	}
-
+// tagRole writes the given attest:* tags to the principal's IAM role.
+func (s *Service) tagRole(ctx context.Context, roleARN string, tags []iamtypes.Tag) error {
 	roleName := extractRoleName(roleARN)
 	if roleName == "" {
 		return fmt.Errorf("could not extract role name from ARN: %s", roleARN)
@@ -783,22 +798,17 @@ func (s *Service) SetIdentityTags(ctx context.Context, userID, labID, adminLevel
 	if roleARN == "" {
 		return fmt.Errorf("no IAM role ARN found for user %s: register the role ARN first", userID)
 	}
-	roleName := extractRoleName(roleARN)
-	if roleName == "" {
-		return fmt.Errorf("could not extract role name from ARN: %s", roleARN)
-	}
 
-	_, err := s.iamTagger.TagRole(ctx, &iam.TagRoleInput{
-		RoleName: aws.String(roleName),
-		Tags: []iamtypes.Tag{
-			{Key: aws.String("attest:lab-id"), Value: aws.String(labID)},
-			{Key: aws.String("attest:admin-level"), Value: aws.String(adminLevel)},
+	tags, err := runProviderToTags(ctx, qualifyasp.AttrID, qualifyasp.AttributesProvider(qualifyasp.AttributesInput{
+		Tags: []qualifyasp.Tag{
+			{Key: TagLabID, Value: labID},
+			{Key: TagAdminLevel, Value: adminLevel},
 		},
-	})
+	}), qualifyasp.Target(roleARN))
 	if err != nil {
-		return fmt.Errorf("tagging IAM role %s: %w", roleName, err)
+		return err
 	}
-	return nil
+	return s.tagRole(ctx, roleARN, tags)
 }
 
 // GetUserProfile retrieves a user's profile from the database.
@@ -900,22 +910,17 @@ func (s *Service) RecordCountryCheck(ctx context.Context, userID, countryCode, p
 	if roleARN == "" {
 		return fmt.Errorf("no IAM role ARN found for user %s: register the role ARN first", userID)
 	}
-	roleName := extractRoleName(roleARN)
-	if roleName == "" {
-		return fmt.Errorf("could not extract role name from ARN: %s", roleARN)
-	}
 
 	expiry := now.AddDate(1, 0, 0).Format(time.RFC3339)
-	_, err = s.iamTagger.TagRole(ctx, &iam.TagRoleInput{
-		RoleName: aws.String(roleName),
-		Tags: []iamtypes.Tag{
-			{Key: aws.String("attest:country"), Value: aws.String(upper)},
-			{Key: aws.String("attest:coc-check-current"), Value: aws.String("true")},
-			{Key: aws.String("attest:coc-check-expiry"), Value: aws.String(expiry)},
+	tags, err := runProviderToTags(ctx, qualifyasp.AttrID, qualifyasp.AttributesProvider(qualifyasp.AttributesInput{
+		Tags: []qualifyasp.Tag{
+			{Key: TagCountry, Value: upper},
+			{Key: TagCOCCheckCurrent, Value: "true"},
+			{Key: TagCOCCheckExpiry, Value: expiry},
 		},
-	})
+	}), qualifyasp.Target(roleARN))
 	if err != nil {
-		return fmt.Errorf("tagging IAM role %s: %w", roleName, err)
+		return err
 	}
-	return nil
+	return s.tagRole(ctx, roleARN, tags)
 }


### PR DESCRIPTION
Closes #40. Follow-up to qualify#38 (#39), which routed training-module tag writing through the evidence kernel but **scoped out** the other two `attest:*` writers. This finishes the qualify re-point: **all** of qualify's `attest:*` emission now flows through `lower.ToAttributes` — no hand-built tag sets remain.

## What changes
- **`SetIdentityTags`** (`attest:lab-id`, `attest:admin-level`) and **`RecordCountryCheck`** (`attest:country`, `attest:coc-check-current`, `-expiry`) now produce their tags through the kernel and the same `tagsFromAttrs` chokepoint.

## Design
- **`internal/evidence`: new `AttributesProvider`** (ASP id `attrs`) — a second `(ASP, appraiser)` pair for *direct* attribute attestation. Unlike training there's no quiz, so the appraiser **always passes**: the verdict is "these recorded attributes are attested as of now" and the claims are the `attest:*` tags. Empty input → `NotApplicable`.
- **`service.go`: extracted `runProviderToTags`** (shared CVM run → appraise → lower path) and **`tagRole`** (the IAM write); `writeAttestTags`, `SetIdentityTags`, `RecordCountryCheck` all use them — one kernel path.
- **Drift guard:** tag keys come from `tags.go` constants (`TagLabID`, `TagCountry`, …); the package never types an `attest:*` literal.

## Contract preserved
Existing `TestRecordCountryCheck_WritesIAMTags` (asserts the exact tags) passes unchanged through the new path. Added `TestSetIdentityTags_WritesIAMTags` (+ no-stray-tags), invalid-admin-level guard, and attributes-provider tests (verbatim emission + empty=NotApplicable). `make check` green.

Completes Stream A's qualify re-point — training, identity, and countries-of-concern all route through the kernel.