### PR TITLE
chore: copyright holder → Playground Logic LLC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Playground Logic
+   Copyright 2026 Playground Logic LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Copyright 2026 Scott Friedman
+Copyright 2026 Playground Logic LLC

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,5 +3,5 @@ version = 1
 [[annotations]]
 path = ["**.json", "**.yaml", "**.yml", "**.sql", "**.md", "**.toml", "**.cedar", "**.cast"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2026 Scott Friedman"
+SPDX-FileCopyrightText = "2026 Playground Logic LLC"
 SPDX-License-Identifier = "Apache-2.0"

--- a/cmd/qualify-agent/handlers_credentials.go
+++ b/cmd/qualify-agent/handlers_credentials.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-agent/handlers_s3.go
+++ b/cmd/qualify-agent/handlers_s3.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-agent/main.go
+++ b/cmd/qualify-agent/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-backend/handlers_audit.go
+++ b/cmd/qualify-backend/handlers_audit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-backend/handlers_dashboard.go
+++ b/cmd/qualify-backend/handlers_dashboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-backend/handlers_training.go
+++ b/cmd/qualify-backend/handlers_training.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-backend/handlers_training_test.go
+++ b/cmd/qualify-backend/handlers_training_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-backend/handlers_users.go
+++ b/cmd/qualify-backend/handlers_users.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify-backend/main.go
+++ b/cmd/qualify-backend/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/qualify/cmd/agent.go
+++ b/cmd/qualify/cmd/agent.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/completion.go
+++ b/cmd/qualify/cmd/completion.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/config.go
+++ b/cmd/qualify/cmd/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/credentials.go
+++ b/cmd/qualify/cmd/credentials.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/lab.go
+++ b/cmd/qualify/cmd/lab.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/onboard.go
+++ b/cmd/qualify/cmd/onboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/root.go
+++ b/cmd/qualify/cmd/root.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/s3.go
+++ b/cmd/qualify/cmd/s3.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/train.go
+++ b/cmd/qualify/cmd/train.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/train_render_test.go
+++ b/cmd/qualify/cmd/train_render_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/cmd/version.go
+++ b/cmd/qualify/cmd/version.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cmd/qualify/main.go
+++ b/cmd/qualify/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/agent/aws/client.go
+++ b/internal/agent/aws/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package aws

--- a/internal/agent/aws/s3.go
+++ b/internal/agent/aws/s3.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package aws

--- a/internal/agent/daemon/daemon.go
+++ b/internal/agent/daemon/daemon.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package daemon

--- a/internal/agent/daemon/daemon_unix.go
+++ b/internal/agent/daemon/daemon_unix.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build unix || darwin

--- a/internal/agent/daemon/daemon_windows.go
+++ b/internal/agent/daemon/daemon_windows.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows

--- a/internal/agent/lockfile/lockfile.go
+++ b/internal/agent/lockfile/lockfile.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package lockfile

--- a/internal/agent/store/store.go
+++ b/internal/agent/store/store.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package store

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package audit

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package audit

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package auth

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package auth

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package auth

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package auth

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package auth

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package database

--- a/internal/evidence/provider.go
+++ b/internal/evidence/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package qualifyasp is qualify's (ASP, appraiser) pair for the provabl/evidence

--- a/internal/evidence/provider_test.go
+++ b/internal/evidence/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package qualifyasp_test

--- a/internal/evidence/trust.go
+++ b/internal/evidence/trust.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package qualifyasp

--- a/internal/license/models.go
+++ b/internal/license/models.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package license handles network-based license validation for the qualify

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package license

--- a/internal/localaudit/audit.go
+++ b/internal/localaudit/audit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package localaudit writes a JSONL audit log to ~/.qualify/audit.log.

--- a/internal/localaudit/audit_test.go
+++ b/internal/localaudit/audit_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package localaudit

--- a/internal/training/complete_module_test.go
+++ b/internal/training/complete_module_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training

--- a/internal/training/country_check_test.go
+++ b/internal/training/country_check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training

--- a/internal/training/models.go
+++ b/internal/training/models.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training

--- a/internal/training/service.go
+++ b/internal/training/service.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training

--- a/internal/training/service_test.go
+++ b/internal/training/service_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training

--- a/internal/training/tags.go
+++ b/internal/training/tags.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training

--- a/internal/training/testhelpers.go
+++ b/internal/training/testhelpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package training


### PR DESCRIPTION
Normalizes the copyright holder to **2026 Playground Logic LLC** (the legal entity) across SPDX file headers, NOTICE, REUSE.toml, and the LICENSE footer. No behavior change; build + tests unaffected.