### PR TITLE
chore: copyright prose → Playground Logic LLC; backfill CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+### Added
+
+- **`attest:*` IAM tags written through the provabl/evidence kernel** (closes #38): training-module
+  completion now appraises via the evidence kernel `(ASP, appraiser)` pair and lowers the verdict to
+  the `attest:*` role tags attest's principal resolver reads, instead of writing tags directly.
+  Ephemeral per-run AM key; the kernel is the single producer of the lowered attributes.
+- **Identity + countries-of-concern routed through the kernel** (closes #40): the researcher's
+  identity attributes and countries-of-concern (COC) determination flow through the same kernel
+  lowering as the training tags, so `attest:*` identity/COC tags carry the same provenance as the
+  training tags rather than being set out-of-band.
+
 ### Changed
 
 - **Completed the `ark` → `qualify` rename** (closes #34): renamed `cmd/ark-agent` → `cmd/qualify-agent` and `cmd/ark-backend` → `cmd/qualify-backend`. Build paths, Dockerfiles, release artifact names, and docs updated to match. The binaries were already emitted as `qualify-agent` / `qualify-backend`; the command directories now agree.

--- a/README.md
+++ b/README.md
@@ -200,4 +200,4 @@ See [COMMERCIAL.md](COMMERCIAL.md) for the full boundary.
 
 ## License
 
-Apache 2.0. Copyright 2026 Scott Friedman.
+Apache 2.0. Copyright 2026 Playground Logic LLC.

--- a/docs/index.html
+++ b/docs/index.html
@@ -501,7 +501,7 @@ qualify lab setup \
             </div>
             <div class="footer-bottom">
                 <span>Made by <a href="https://github.com/scttfrdmn">@scttfrdmn</a></span>
-                <span>© 2026 Scott Friedman. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
+                <span>© 2026 Playground Logic LLC. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
Sweeps README/docs prose copyright to Playground Logic LLC and backfills `[Unreleased]` with the evidence-kernel training work that merged without entries: `attest:*` tags through the kernel (#38) and identity/COC routing (#40). Docs only.