### PR TITLE
feat(training): versioned attest:* tag contract + conformance test (closes #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **Versioned `attest:*` tag schema contract** (closes #32): the `attest:*` IAM tag namespace shared
+  with attest is now anchored by a canonical, machine-readable
+  `internal/training/attest-tags-schema.json` (byte-identical with attest's copy) plus a
+  `SchemaVersion` constant. A conformance test (`internal/training/tags_schema_test.go`) locks
+  qualify's tag constants, `moduleTagMap`, and `ModuleExpiryTag` to the schema, so any key drift
+  fails CI instead of silently breaking Cedar evaluation. No new module dependency (the two
+  products stay decoupled — the byte-identical schema + shared `SchemaVersion` are the contract).
+  See attest's `docs/integrations/qualify.md`.
 - **`attest:*` IAM tags written through the provabl/evidence kernel** (closes #38): training-module
   completion now appraises via the evidence kernel `(ASP, appraiser)` pair and lowers the verdict to
   the `attest:*` role tags attest's principal resolver reads, instead of writing tags directly.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ qualify agent (local)
 
 qualify writes IAM tags in the format `attest:<training-id> = true` with a companion `attest:<training-id>-expiry = <ISO8601>`. attest's Cedar PDP reads these during access evaluation. Tags are written to the role registered via `qualify lab register-role`.
 
+The `attest:*` tag contract is a **versioned schema** shared with attest (qualify#32). The canonical, machine-readable schema is [`internal/training/attest-tags-schema.json`](internal/training/attest-tags-schema.json) — byte-identical to attest's `pkg/schema/attest-tags-schema.json`. A conformance test (`internal/training/tags_schema_test.go`) locks qualify's tag constants, `moduleTagMap`, and `ModuleExpiryTag` to that schema, and checks `SchemaVersion` matches, so any key drift fails CI instead of silently breaking Cedar evaluation. To change a key: edit the schema in **both** repos (keep them byte-identical), update the constants, bump `SchemaVersion` in both, and release together. Full contract: attest's `docs/integrations/qualify.md`.
+
 ### Integration with ground
 
 ground's `external_services` config declares that qualify is deployed. ground exports this to `ground-meta.json`; attest reads it to know that training-gated access is in effect.

--- a/internal/training/attest-tags-schema.json
+++ b/internal/training/attest-tags-schema.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Canonical schema for the attest:* IAM role tag namespace shared between qualify (writer) and attest (reader). This file is byte-identical in both repos: provabl/attest pkg/schema/attest-tags-schema.json and provabl/qualify internal/training/attest-tags-schema.json. attest owns the namespace. Each repo embeds this file and a conformance test locks its Go constants to it, so any key change fails CI until BOTH the schema and the version are updated. See https://github.com/provabl/qualify/issues/32.",
+  "version": 1,
+  "namespace": "attest:",
+  "tags": [
+    { "key": "attest:cui-training",                      "writer": "qualify", "type": "bool",      "module": "cui-fundamentals",               "expiry": "attest:cui-training-expiry" },
+    { "key": "attest:cui-training-expiry",               "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:hipaa-training",                    "writer": "qualify", "type": "bool",      "module": "hipaa-privacy-security",         "expiry": "attest:hipaa-training-expiry" },
+    { "key": "attest:hipaa-training-expiry",             "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:awareness-training",                "writer": "qualify", "type": "bool",      "module": "security-awareness",            "expiry": "attest:awareness-training-expiry" },
+    { "key": "attest:awareness-training-expiry",         "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:ferpa-training",                    "writer": "qualify", "type": "bool",      "module": "ferpa-basics",                  "expiry": "attest:ferpa-training-expiry" },
+    { "key": "attest:ferpa-training-expiry",             "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:itar-training",                     "writer": "qualify", "type": "bool",      "module": "itar-export-control",           "expiry": "attest:itar-training-expiry" },
+    { "key": "attest:itar-training-expiry",              "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:data-class-training",               "writer": "qualify", "type": "bool",      "module": "data-classification",           "expiry": "attest:data-class-training-expiry" },
+    { "key": "attest:data-class-training-expiry",        "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:research-security-training",        "writer": "qualify", "type": "bool",      "module": "nih-research-security",         "expiry": "attest:research-security-training-expiry" },
+    { "key": "attest:research-security-training-expiry", "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:coc-check-current",                 "writer": "qualify", "type": "bool",      "module": "countries-of-concern-awareness", "expiry": "attest:coc-check-expiry" },
+    { "key": "attest:coc-check-expiry",                  "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:country",                           "writer": "qualify", "type": "string" },
+    { "key": "attest:lab-id",                            "writer": "qualify", "type": "string" },
+    { "key": "attest:admin-level",                       "writer": "qualify", "type": "string" },
+    { "key": "attest:nih-approval",                      "writer": "attest",  "type": "bool",      "expiry": "attest:nih-approval-expiry" },
+    { "key": "attest:nih-approval-expiry",               "writer": "attest",  "type": "timestamp" },
+    { "key": "attest:nih-dua-id",                        "writer": "attest",  "type": "string" },
+    { "key": "attest:cui-expiry",                        "writer": "legacy",  "type": "timestamp" }
+  ]
+}

--- a/internal/training/tags.go
+++ b/internal/training/tags.go
@@ -3,23 +3,68 @@
 
 package training
 
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
 // attest:* IAM tag schema — single source of truth for qualify.
 //
 // qualify writes these tags to researchers' IAM roles on training completion.
 // attest's principal resolver (internal/principal/resolver.go) reads them
 // to populate Cedar principal attributes during access evaluation.
 //
-// Schema version: 1
-//
-// IMPORTANT: Both repos must agree on these key strings. If any key changes,
-// update this file AND attest's principal resolver in the same release.
+// IMPORTANT: Both repos must agree on these key strings AND on SchemaVersion. The
+// canonical contract is attest-tags-schema.json (embedded below, byte-identical with
+// attest's pkg/schema/attest-tags-schema.json); the conformance test in
+// tags_schema_test.go locks these constants — and moduleTagMap / ModuleExpiryTag —
+// to it. If any key changes, update the schema JSON in BOTH repos and bump
+// SchemaVersion in the same release.
 // See: https://github.com/provabl/qualify/issues/32
 //
 // Key naming convention:
 //
 //	attest:<capability>            boolean flag ("true")
 //	attest:<capability>-expiry     RFC3339 timestamp of when the flag expires
+
+// SchemaVersion is the version of the attest:* IAM tag contract shared with attest.
+// It MUST equal the "version" field of the embedded canonical schema and the same
+// constant in attest's pkg/schema/tags.go. Bump it (in both repos, same release)
+// whenever a tag key is added, removed, or renamed.
+const SchemaVersion = 1
+
+// canonicalTagsSchemaJSON is the byte-identical canonical schema, also present in
+// attest at pkg/schema/attest-tags-schema.json.
 //
+//go:embed attest-tags-schema.json
+var canonicalTagsSchemaJSON []byte
+
+// TagSchemaEntry is one row of the canonical schema.
+type TagSchemaEntry struct {
+	Key    string `json:"key"`
+	Writer string `json:"writer"` // "qualify" | "attest" | "legacy"
+	Type   string `json:"type"`   // "bool" | "timestamp" | "string"
+	Module string `json:"module,omitempty"`
+	Expiry string `json:"expiry,omitempty"`
+}
+
+// TagSchema is the parsed canonical schema.
+type TagSchema struct {
+	Version   int              `json:"version"`
+	Namespace string           `json:"namespace"`
+	Tags      []TagSchemaEntry `json:"tags"`
+}
+
+// LoadTagSchema parses the embedded canonical attest:* tag schema.
+func LoadTagSchema() (*TagSchema, error) {
+	var s TagSchema
+	if err := json.Unmarshal(canonicalTagsSchemaJSON, &s); err != nil {
+		return nil, fmt.Errorf("parse canonical attest-tags-schema.json: %w", err)
+	}
+	return &s, nil
+}
+
 // Training completion tags (written by svc.CompleteModule):
 const (
 	TagCUITraining              = "attest:cui-training"

--- a/internal/training/tags_schema_test.go
+++ b/internal/training/tags_schema_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package training
+
+import (
+	"sort"
+	"testing"
+)
+
+// declaredTagConstants is every attest:* tag key constant declared in tags.go.
+// The conformance test locks this set to the canonical schema, so adding, removing,
+// or renaming a constant without updating attest-tags-schema.json (and attest's
+// byte-identical copy, same release) fails CI. The guard against the silent
+// qualify↔attest drift in qualify#32.
+var declaredTagConstants = []string{
+	TagCUITraining,
+	TagCUITrainingExpiry,
+	TagHIPAATraining,
+	TagHIPAATrainingExpiry,
+	TagAwarenessTraining,
+	TagAwarenessTrainingExpiry,
+	TagFERPATraining,
+	TagFERPATrainingExpiry,
+	TagITARTraining,
+	TagITARTrainingExpiry,
+	TagDataClassTraining,
+	TagDataClassTrainingExpiry,
+	TagResearchSecurityTraining,
+	TagResearchSecurityExpiry,
+	TagCOCCheckCurrent,
+	TagCOCCheckExpiry,
+	TagCountry,
+	TagLabID,
+	TagAdminLevel,
+}
+
+// TestSchemaVersionMatchesCanonical guards that qualify's SchemaVersion constant and
+// the embedded canonical schema agree. The same assertion runs in attest against its
+// byte-identical copy — together they make SchemaVersion a meaningful cross-repo
+// signal: a key change forces a bump that both conformance tests check.
+func TestSchemaVersionMatchesCanonical(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+	if s.Version != SchemaVersion {
+		t.Errorf("canonical schema version = %d, SchemaVersion const = %d — bump them together", s.Version, SchemaVersion)
+	}
+	if s.Namespace != "attest:" {
+		t.Errorf("schema namespace = %q, want %q", s.Namespace, "attest:")
+	}
+}
+
+// TestQualifyConstantsMatchSchema asserts qualify declares a constant for every
+// attest:* key it is the writer of (writer == "qualify"), and declares no qualify
+// constant absent from the schema. (qualify does not declare the attest-written NIH
+// keys or the legacy key — those belong to attest's side of the contract.)
+func TestQualifyConstantsMatchSchema(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+
+	qualifyKeys := make(map[string]bool)
+	for _, e := range s.Tags {
+		if e.Writer == "qualify" {
+			qualifyKeys[e.Key] = true
+		}
+	}
+	declared := make(map[string]bool, len(declaredTagConstants))
+	for _, k := range declaredTagConstants {
+		declared[k] = true
+	}
+
+	for k := range qualifyKeys {
+		if !declared[k] {
+			t.Errorf("schema key %q (writer=qualify) has no qualify constant — add it to tags.go and declaredTagConstants", k)
+		}
+	}
+	for k := range declared {
+		if !qualifyKeys[k] {
+			t.Errorf("qualify constant %q is not a writer=qualify key in the canonical schema — fix the schema (both repos) and bump SchemaVersion", k)
+		}
+	}
+	if len(declaredTagConstants) != len(qualifyKeys) {
+		t.Errorf("count mismatch: %d qualify constants vs %d writer=qualify schema keys\n declared: %v\n schema:   %v",
+			len(declaredTagConstants), len(qualifyKeys), sortedKeys(declared), sortedKeys(qualifyKeys))
+	}
+}
+
+// TestModuleTagMapMatchesSchema asserts the module → tag mapping qualify writes by
+// agrees with the schema's "module" metadata, both directions: every schema entry
+// with a module maps to it in moduleTagMap, and every moduleTagMap entry is backed
+// by a schema "module" field. This is what keeps TagForModule honest.
+func TestModuleTagMapMatchesSchema(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+
+	schemaModuleToKey := make(map[string]string)
+	for _, e := range s.Tags {
+		if e.Module != "" {
+			schemaModuleToKey[e.Module] = e.Key
+		}
+	}
+
+	for module, wantKey := range schemaModuleToKey {
+		if got := TagForModule(module); got != wantKey {
+			t.Errorf("TagForModule(%q) = %q, schema says %q", module, got, wantKey)
+		}
+	}
+	for module, key := range moduleTagMap {
+		if schemaModuleToKey[module] != key {
+			t.Errorf("moduleTagMap[%q] = %q has no matching schema module entry — add a \"module\" field in attest-tags-schema.json (both repos)", module, key)
+		}
+	}
+	if len(moduleTagMap) != len(schemaModuleToKey) {
+		t.Errorf("count mismatch: %d moduleTagMap entries vs %d schema entries with a module", len(moduleTagMap), len(schemaModuleToKey))
+	}
+}
+
+// TestModuleExpiryTagMatchesSchema asserts ModuleExpiryTag agrees with the schema's
+// "expiry" metadata for every key that has one. Scoped to writer=qualify keys:
+// ModuleExpiryTag is a qualify-side helper and deliberately does not know attest's
+// own keys (e.g. the NIH approval pair), so the schema's writer field is the
+// authority on which expiry pairings qualify is responsible for.
+func TestModuleExpiryTagMatchesSchema(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+	for _, e := range s.Tags {
+		if e.Expiry == "" || e.Writer != "qualify" {
+			continue
+		}
+		if got := ModuleExpiryTag(e.Key); got != e.Expiry {
+			t.Errorf("ModuleExpiryTag(%q) = %q, schema says %q", e.Key, got, e.Expiry)
+		}
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
Closes #32 — the silent qualify↔attest tag-drift gap, **qualify (writer) side**.

## Problem
The `attest:*` tag namespace was defined independently in each repo; a rename on either side silently broke the other (Cedar then sees the attribute as missing, not an error).

## Approach (no new dependency)
No `provabl/*` coupling added — the byte-identical schema + shared `SchemaVersion` *are* the contract:
- **`internal/training/attest-tags-schema.json`** — canonical schema, byte-identical with attest's `pkg/schema/attest-tags-schema.json`.
- **`SchemaVersion` const** + embed/parse.
- **`internal/training/tags_schema_test.go`** — locks qualify's `writer:qualify` tag constants, `moduleTagMap` (← schema `module`), and `ModuleExpiryTag` (← schema `expiry`) to the schema, and asserts `SchemaVersion` matches. **Verified it fails CI on a renamed key.**
- README documents the contract + bump rule.

## Companion
attest side: PR on `feat/versioned-tag-schema` in provabl/attest (reader-side conformance). Both carry the byte-identical schema; **merge together**.