### PR TITLE
feat(preflight): qualify preflight verifies the caller's IAM permissions (provabl#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`qualify preflight`** (provabl#16): verifies the calling principal holds the IAM action qualify
+  needs (`iam:TagRole`, to write `attest:*` training/identity tags) via read-only
+  `iam:SimulatePrincipalPolicy` against the caller ARN. Renders ✓/✗ per action with remediation;
+  exits non-zero on any deny; fail-closed on an un-callable check. New `internal/preflight`
+  (mock-driven tests). Mirrors attest/ground. See `docs/required-permissions.md`.
 - **Versioned `attest:*` tag schema contract** (closes #32): the `attest:*` IAM tag namespace shared
   with attest is now anchored by a canonical, machine-readable
   `internal/training/attest-tags-schema.json` (byte-identical with attest's copy) plus a

--- a/cmd/qualify/cmd/preflight.go
+++ b/cmd/qualify/cmd/preflight.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/provabl/qualify/internal/preflight"
+)
+
+func init() {
+	rootCmd.AddCommand(preflightCmd)
+	preflightCmd.Flags().String("region", "us-east-1", "AWS region")
+}
+
+var preflightCmd = &cobra.Command{
+	Use:   "preflight",
+	Short: "Verify the calling principal holds the IAM permissions qualify needs",
+	Long: `Check that the calling AWS principal can perform qualify's AWS-touching action
+(iam:TagRole, to write attest:* training/identity tags) via read-only
+iam:SimulatePrincipalPolicy against the caller — it evaluates, it does not act.
+A denied action prints a remediation and the command exits non-zero. See the
+suite's docs/required-permissions.md.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		region, _ := cmd.Flags().GetString("region")
+		results := preflight.CheckCallerPermissions(cmd.Context(), region)
+		failures := 0
+		for _, r := range results {
+			if r.Status {
+				fmt.Printf("  ✓ %s\n", r.Name)
+				continue
+			}
+			failures++
+			fmt.Printf("  ✗ %s: %s\n", r.Name, r.Detail)
+			if r.Remediation != "" {
+				fmt.Printf("      Remediation: %s\n", r.Remediation)
+			}
+		}
+		fmt.Println()
+		if failures > 0 {
+			return fmt.Errorf("preflight failed: %d required permission(s) missing", failures)
+		}
+		fmt.Println("✓ All required permissions present")
+		return nil
+	},
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package preflight verifies that the calling AWS principal holds the IAM actions
+// qualify needs for its AWS-touching operations. It uses read-only
+// iam:SimulatePrincipalPolicy against the caller ARN (from sts:GetCallerIdentity) —
+// it evaluates, it never acts. This catches an under-permissioned account up front,
+// before an operation fails mid-way.
+//
+// It mirrors attest's and ground's caller-permission check (provabl#16). The suite
+// tools are deliberately decoupled — the evidence kernel is the only shared
+// dependency, and it is stdlib-only — so each tool carries its own small copy of
+// this generic check rather than introducing a shared AWS-SDK library. The per-tool
+// action lists are documented in the suite's docs/required-permissions.md.
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// Result is the outcome of one permission check.
+type Result struct {
+	Name        string // the action, e.g. "iam:TagRole"
+	Severity    string // "ok" | "error"
+	Status      bool   // true when the action is permitted
+	Detail      string // what was found
+	Remediation string // actionable step when Status is false
+}
+
+type stsIdentityAPI interface {
+	GetCallerIdentity(ctx context.Context, in *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+type iamSimAPI interface {
+	SimulatePrincipalPolicy(ctx context.Context, in *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+// qualifyRequiredActions are the AWS IAM actions qualify needs. On training-module
+// completion qualify writes attest:* training/identity tags onto a researcher's IAM
+// role (iam:TagRole). iam:SimulatePrincipalPolicy is included because this preflight
+// itself needs it. See docs/required-permissions.md.
+var qualifyRequiredActions = []string{
+	"sts:GetCallerIdentity",
+	"iam:SimulatePrincipalPolicy",
+	"iam:TagRole",
+}
+
+// CheckCallerPermissions loads AWS config for the region and verifies the calling
+// principal holds qualify's required actions. Fail-closed: a config/credential
+// failure is an error result, not a silent pass.
+func CheckCallerPermissions(ctx context.Context, region string) []Result {
+	if region == "" {
+		region = "us-east-1"
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return []Result{{
+			Name: "AWS credentials", Severity: "error", Status: false,
+			Detail:      err.Error(),
+			Remediation: "Configure AWS credentials: aws configure or set AWS_PROFILE",
+		}}
+	}
+	return check(ctx, sts.NewFromConfig(cfg), iam.NewFromConfig(cfg))
+}
+
+func check(ctx context.Context, stsSvc stsIdentityAPI, iamSvc iamSimAPI) []Result {
+	ident, err := stsSvc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return []Result{{
+			Name: "Caller identity", Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("sts:GetCallerIdentity failed: %v", err),
+			Remediation: "Ensure valid AWS credentials with sts:GetCallerIdentity",
+		}}
+	}
+	callerARN := aws.ToString(ident.Arn)
+
+	out, err := iamSvc.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(callerARN),
+		ActionNames:     qualifyRequiredActions,
+	})
+	if err != nil {
+		return []Result{{
+			Name: "IAM permission self-check", Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("iam:SimulatePrincipalPolicy failed for %s: %v", callerARN, err),
+			Remediation: "Grant iam:SimulatePrincipalPolicy to run the preflight (or review required-permissions.md manually)",
+		}}
+	}
+
+	var results []Result
+	for _, ev := range out.EvaluationResults {
+		action := aws.ToString(ev.EvalActionName)
+		if ev.EvalDecision == iamtypes.PolicyEvaluationDecisionTypeAllowed {
+			results = append(results, Result{Name: action, Severity: "ok", Status: true, Detail: "allowed"})
+			continue
+		}
+		results = append(results, Result{
+			Name: action, Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("%s for %s", string(ev.EvalDecision), callerARN),
+			Remediation: "Grant " + action + " to the qualify principal (see required-permissions.md)",
+		})
+	}
+	if len(results) == 0 {
+		return []Result{{
+			Name: "IAM permission self-check", Severity: "error", Status: false,
+			Detail:      "simulator returned no evaluation results",
+			Remediation: "Review required-permissions.md and the qualify principal's policy",
+		}}
+	}
+	return results
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type mockSTS struct {
+	arn string
+	err error
+}
+
+func (m mockSTS) GetCallerIdentity(_ context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &sts.GetCallerIdentityOutput{Arn: aws.String(m.arn)}, nil
+}
+
+type mockIAMSim struct {
+	denied map[string]bool
+	err    error
+}
+
+func (m mockIAMSim) SimulatePrincipalPolicy(_ context.Context, in *iam.SimulatePrincipalPolicyInput, _ ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	var results []iamtypes.EvaluationResult
+	for _, a := range in.ActionNames {
+		dec := iamtypes.PolicyEvaluationDecisionTypeAllowed
+		if m.denied[a] {
+			dec = iamtypes.PolicyEvaluationDecisionTypeExplicitDeny
+		}
+		results = append(results, iamtypes.EvaluationResult{EvalActionName: aws.String(a), EvalDecision: dec})
+	}
+	return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}, nil
+}
+
+const testARN = "arn:aws:iam::942542972736:role/qualify-runner"
+
+func allOK(rs []Result) bool {
+	for _, r := range rs {
+		if !r.Status {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCheck_AllAllowed(t *testing.T) {
+	rs := check(context.Background(), mockSTS{arn: testARN}, mockIAMSim{})
+	if len(rs) != len(qualifyRequiredActions) {
+		t.Fatalf("expected %d results, got %d", len(qualifyRequiredActions), len(rs))
+	}
+	if !allOK(rs) {
+		t.Error("expected all actions allowed → all ok")
+	}
+}
+
+// A denied action surfaces as a non-ok result with remediation (fail-closed).
+func TestCheck_DeniedActionIsError(t *testing.T) {
+	target := qualifyRequiredActions[len(qualifyRequiredActions)-1] // the tool-specific action
+	rs := check(context.Background(), mockSTS{arn: testARN}, mockIAMSim{denied: map[string]bool{target: true}})
+	var found bool
+	for _, r := range rs {
+		if r.Name == target {
+			found = true
+			if r.Status || r.Severity != "error" || r.Remediation == "" {
+				t.Errorf("denied action = %+v; want non-ok error with remediation", r)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no result for the denied action %q", target)
+	}
+	if allOK(rs) {
+		t.Error("a denied action must make the set not-all-ok")
+	}
+}
+
+func TestCheck_CallerIdentityErrorFailsClosed(t *testing.T) {
+	rs := check(context.Background(), mockSTS{err: errors.New("ExpiredToken")}, mockIAMSim{})
+	if len(rs) != 1 || rs[0].Status {
+		t.Fatalf("expected one error result on GetCallerIdentity failure, got %+v", rs)
+	}
+}
+
+func TestCheck_SimulatorErrorFailsClosed(t *testing.T) {
+	rs := check(context.Background(), mockSTS{arn: testARN}, mockIAMSim{err: errors.New("AccessDenied")})
+	if len(rs) != 1 || rs[0].Status {
+		t.Fatalf("expected one fail-closed error result on simulator failure, got %+v", rs)
+	}
+	if rs[0].Remediation == "" {
+		t.Error("fail-closed result should explain how to enable the self-check")
+	}
+}


### PR DESCRIPTION
Rolls the caller-permission preflight (the attest/ground pattern) to **qualify**. `qualify preflight` simulates the actions qualify needs against the caller ARN via read-only `iam:SimulatePrincipalPolicy` — allowed → ✓, denied → ✗ + remediation, fail-closed on an un-callable check, exits non-zero on any deny. New `internal/preflight` + mock-driven tests (allowed/denied/both fail-closed paths). Duplicated rather than shared, preserving the suite's decoupling. Verified live where applicable.

Refs: provabl#16