### PR TITLE
feat(schema): attest:* tag schema v2 — lockstep with attest#112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Changed
 
+- **attest:* tag schema → v2** (provabl#11, qualify#32; provabl ADR 0002): the canonical
+  `attest-tags-schema.json` (byte-identical with attest) renames the attest-written `attest:nih-dua-id`
+  (string) to `attest:nih-dua-ids` (a `+`-delimited set), and `SchemaVersion` bumps 1→2. qualify writes
+  no NIH key (it is `writer: "attest"`), so no qualify constant changes — but the shared version moves
+  in lockstep and qualify's conformance test re-locks against the updated schema, which is exactly the
+  cross-repo drift guard qualify#32 exists to provide.
 - **SLSA L3 release provenance** (provabl#5): `release.yml` now generates provenance via the
   `slsa-framework/slsa-github-generator` reusable workflow (isolated, non-falsifiable builder)
   instead of `actions/attest-build-provenance` (L2). One runner now builds all three binaries

--- a/internal/training/attest-tags-schema.json
+++ b/internal/training/attest-tags-schema.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Canonical schema for the attest:* IAM role tag namespace shared between qualify (writer) and attest (reader). This file is byte-identical in both repos: provabl/attest pkg/schema/attest-tags-schema.json and provabl/qualify internal/training/attest-tags-schema.json. attest owns the namespace. Each repo embeds this file and a conformance test locks its Go constants to it, so any key change fails CI until BOTH the schema and the version are updated. See https://github.com/provabl/qualify/issues/32.",
-  "version": 1,
+  "$comment": "Canonical schema for the attest:* IAM role tag namespace shared between qualify (writer) and attest (reader). This file is byte-identical in both repos: provabl/attest pkg/schema/attest-tags-schema.json and provabl/qualify internal/training/attest-tags-schema.json. attest owns the namespace. Each repo embeds this file and a conformance test locks its Go constants to it, so any key change fails CI until BOTH the schema and the version are updated. See https://github.com/provabl/qualify/issues/32. The 'set' type is a delimited multi-value tag value: members joined with '+' (comma is not a valid IAM tag-value character; '+' is). See https://github.com/provabl/provabl/blob/main/docs/adr/0002-compute-to-data-access.md.",
+  "version": 2,
   "namespace": "attest:",
   "tags": [
     { "key": "attest:cui-training",                      "writer": "qualify", "type": "bool",      "module": "cui-fundamentals",               "expiry": "attest:cui-training-expiry" },
@@ -24,7 +24,7 @@
     { "key": "attest:admin-level",                       "writer": "qualify", "type": "string" },
     { "key": "attest:nih-approval",                      "writer": "attest",  "type": "bool",      "expiry": "attest:nih-approval-expiry" },
     { "key": "attest:nih-approval-expiry",               "writer": "attest",  "type": "timestamp" },
-    { "key": "attest:nih-dua-id",                        "writer": "attest",  "type": "string" },
+    { "key": "attest:nih-dua-ids",                       "writer": "attest",  "type": "set" },
     { "key": "attest:cui-expiry",                        "writer": "legacy",  "type": "timestamp" }
   ]
 }

--- a/internal/training/tags.go
+++ b/internal/training/tags.go
@@ -32,7 +32,12 @@ import (
 // It MUST equal the "version" field of the embedded canonical schema and the same
 // constant in attest's pkg/schema/tags.go. Bump it (in both repos, same release)
 // whenever a tag key is added, removed, or renamed.
-const SchemaVersion = 1
+//
+// v2 (2026-06): attest:nih-dua-id (string) → attest:nih-dua-ids (set), an
+// attest-written key. qualify declares no constant for it (it is not a
+// writer=qualify key), but the shared version still bumps in lockstep. See
+// provabl ADR 0002 (compute-to-data-access).
+const SchemaVersion = 2
 
 // canonicalTagsSchemaJSON is the byte-identical canonical schema, also present in
 // attest at pkg/schema/attest-tags-schema.json.
@@ -44,7 +49,7 @@ var canonicalTagsSchemaJSON []byte
 type TagSchemaEntry struct {
 	Key    string `json:"key"`
 	Writer string `json:"writer"` // "qualify" | "attest" | "legacy"
-	Type   string `json:"type"`   // "bool" | "timestamp" | "string"
+	Type   string `json:"type"`   // "bool" | "timestamp" | "string" | "set"
 	Module string `json:"module,omitempty"`
 	Expiry string `json:"expiry,omitempty"`
 }


### PR DESCRIPTION
Lockstep half of the schema bump for the compute-to-data chain (provabl#11 Tier 2; design in provabl ADR 0002). Companion to **provabl/attest#112**.

attest renames its **attest-written** `attest:nih-dua-id` (string) → `attest:nih-dua-ids` (a `+`-delimited set) so a researcher's multiple study DUAs can each be matched to a dataset. qualify writes **no** NIH key (it is `writer: "attest"`), so no qualify constant changes — but the shared contract must stay in lockstep:

- **`attest-tags-schema.json`**: refreshed to the byte-identical v2 (`version` 1 → 2, the renamed set-typed key). Verified `diff`-identical with attest's copy.
- **`SchemaVersion` 1 → 2**; `TagSchemaEntry` type comment notes `set`.

This is exactly what **qualify#32** built the versioned schema for: a key change on attest's side forces a version bump that qualify's conformance test re-locks against, so the two can't silently drift. Both repos' full test suites pass.

Must merge in the **same release** as attest#112. Refs: provabl#11, qualify#32.