### PR TITLE
feat(schema): tag namespace v3 — complete registry, lockstep with attest#116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Changed
 
+- **attest:* tag schema → v3** (provabl ADR 0003; epic provabl#30): the canonical
+  `attest-tags-schema.json` (byte-identical with attest) becomes the **complete** namespace registry —
+  adds vet/nitro/tpm producer tags (`attest:vetted`, `attest:pcr<N>`, `attest:enclave-attested`,
+  `attest:boot-attested`, the last two splitting the conflated `attest:nitro-attested`). None are
+  `writer:qualify`, so **no qualify constant changes** — but the shared `SchemaVersion` bumps 2→3 in
+  lockstep, the `TagSchemaEntry` struct gains a `Pattern` field + new `writer` values, and qualify's
+  writer-scoped conformance test re-locks against the updated registry. The cross-repo drift guard
+  (qualify#32) extends to the whole namespace.
 - **attest:* tag schema → v2** (provabl#11, qualify#32; provabl ADR 0002): the canonical
   `attest-tags-schema.json` (byte-identical with attest) renames the attest-written `attest:nih-dua-id`
   (string) to `attest:nih-dua-ids` (a `+`-delimited set), and `SchemaVersion` bumps 1→2. qualify writes

--- a/internal/training/attest-tags-schema.json
+++ b/internal/training/attest-tags-schema.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Canonical schema for the attest:* IAM role tag namespace shared between qualify (writer) and attest (reader). This file is byte-identical in both repos: provabl/attest pkg/schema/attest-tags-schema.json and provabl/qualify internal/training/attest-tags-schema.json. attest owns the namespace. Each repo embeds this file and a conformance test locks its Go constants to it, so any key change fails CI until BOTH the schema and the version are updated. See https://github.com/provabl/qualify/issues/32. The 'set' type is a delimited multi-value tag value: members joined with '+' (comma is not a valid IAM tag-value character; '+' is). See https://github.com/provabl/provabl/blob/main/docs/adr/0002-compute-to-data-access.md.",
-  "version": 2,
+  "$comment": "Canonical registry of the complete attest:* IAM tag namespace, shared across the suite: qualify (training/identity), attest (NIH approval), vet (AMI vetting), nitro (enclave attestation), tpm (boot attestation) write; attest's resolver + ground's SCPs read. This file is byte-identical in every repo that embeds it. Each writer's repo carries a conformance test locking ITS OWN constants (writer-scoped) to this registry, so a rename fails that writer's CI rather than silently in production. Any key add/remove/rename bumps 'version'. The 'set' type is a '+'-delimited multi-value tag value (comma is not a valid IAM tag-value character). A 'pattern' entry (e.g. attest:pcr<N>) documents a family of keys whose suffix varies. See https://github.com/provabl/provabl/blob/main/docs/adr/0003-attest-tag-namespace-no-conflation.md and 0002-compute-to-data-access.md.",
+  "version": 3,
   "namespace": "attest:",
   "tags": [
     { "key": "attest:cui-training",                      "writer": "qualify", "type": "bool",      "module": "cui-fundamentals",               "expiry": "attest:cui-training-expiry" },
@@ -25,6 +25,10 @@
     { "key": "attest:nih-approval",                      "writer": "attest",  "type": "bool",      "expiry": "attest:nih-approval-expiry" },
     { "key": "attest:nih-approval-expiry",               "writer": "attest",  "type": "timestamp" },
     { "key": "attest:nih-dua-ids",                       "writer": "attest",  "type": "set" },
+    { "key": "attest:vetted",                            "writer": "vet",     "type": "bool" },
+    { "key": "attest:pcr<N>",                            "writer": "vet",     "type": "string", "pattern": true },
+    { "key": "attest:enclave-attested",                  "writer": "nitro",   "type": "bool" },
+    { "key": "attest:boot-attested",                     "writer": "tpm",     "type": "bool" },
     { "key": "attest:cui-expiry",                        "writer": "legacy",  "type": "timestamp" }
   ]
 }

--- a/internal/training/tags.go
+++ b/internal/training/tags.go
@@ -37,7 +37,13 @@ import (
 // attest-written key. qualify declares no constant for it (it is not a
 // writer=qualify key), but the shared version still bumps in lockstep. See
 // provabl ADR 0002 (compute-to-data-access).
-const SchemaVersion = 2
+//
+// v3 (2026-06): the schema becomes the complete attest:* namespace registry —
+// adds vet/nitro/tpm producer tags (attest:vetted, attest:pcr<N>,
+// attest:enclave-attested, attest:boot-attested). None are writer=qualify, so no
+// qualify constant changes, but the shared version bumps in lockstep. See provabl
+// ADR 0003 (attest-tag-namespace-no-conflation).
+const SchemaVersion = 3
 
 // canonicalTagsSchemaJSON is the byte-identical canonical schema, also present in
 // attest at pkg/schema/attest-tags-schema.json.
@@ -45,13 +51,14 @@ const SchemaVersion = 2
 //go:embed attest-tags-schema.json
 var canonicalTagsSchemaJSON []byte
 
-// TagSchemaEntry is one row of the canonical schema.
+// TagSchemaEntry is one row of the canonical registry.
 type TagSchemaEntry struct {
-	Key    string `json:"key"`
-	Writer string `json:"writer"` // "qualify" | "attest" | "legacy"
-	Type   string `json:"type"`   // "bool" | "timestamp" | "string" | "set"
-	Module string `json:"module,omitempty"`
-	Expiry string `json:"expiry,omitempty"`
+	Key     string `json:"key"`
+	Writer  string `json:"writer"` // "qualify" | "attest" | "vet" | "nitro" | "tpm" | "legacy"
+	Type    string `json:"type"`   // "bool" | "timestamp" | "string" | "set"
+	Module  string `json:"module,omitempty"`
+	Expiry  string `json:"expiry,omitempty"`
+	Pattern bool   `json:"pattern,omitempty"` // true if Key is a family (e.g. attest:pcr<N>)
 }
 
 // TagSchema is the parsed canonical schema.


### PR DESCRIPTION
Qualify side of ADR 0003 (epic provabl#30). **Companion to provabl/attest#116 — must merge in the same release** (byte-identical schema + matching `SchemaVersion`).

## What changed
The canonical `attest-tags-schema.json` (byte-identical with attest) becomes the **complete** `attest:*` namespace registry — adds the vet/nitro/tpm producer tags (`attest:vetted`, `attest:pcr<N>`, `attest:enclave-attested`, `attest:boot-attested`, the last two splitting the conflated `attest:nitro-attested`).

**No qualify constant changes** — none of the new tags are `writer:qualify`. But the contract moves in lockstep:
- shared `SchemaVersion` 2→3,
- `TagSchemaEntry` gains a `Pattern` field + new `writer` values,
- qualify's writer-scoped conformance test re-locks against the updated registry.

This is exactly the cross-repo drift guard qualify#32 built — now extended to the whole namespace. Training tests green.

Verified `diff`-identical with attest's copy. Refs: provabl#30.