### PR TITLE
fix(security): remove spoofable chi RealIP middleware (GO-2026-5774/5775/5777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+### Security
+
+- **Removed chi's `middleware.RealIP` from both HTTP servers** (and bumped `github.com/go-chi/chi/v5`
+  v5.2.3 → v5.3.0), clearing **GO-2026-5774**, **GO-2026-5775**, and **GO-2026-5777**. `RealIP`
+  rewrites `r.RemoteAddr` from the leftmost `X-Forwarded-For` (or `True-Client-IP` / `X-Real-IP`)
+  value whether or not a trusted proxy set it, so **any client could forge the client address qualify
+  logs**. All three advisories were symbol-reachable — `qualify-agent` and `qualify-backend` both
+  mounted it.
+  **The version bump alone is not a fix:** chi v5.3.0 *deprecates* `RealIP` rather than repairing it
+  (the design can't distinguish a proxy-set header from a forged one), so upgrading only silences
+  govulncheck. Removing the middleware is what actually closes the hole — with it gone,
+  `r.RemoteAddr` is the true TCP peer. Neither server sits behind a proxy, so nothing is lost.
+  This is a log-integrity fix, not an evidence-integrity one: the spoofable value reached the `slog`
+  request line (`remote_addr`), *not* the training audit record — `audit.Entry.IPAddress` is
+  currently never populated. It still matters for a compliance tool, whose request logs are operator
+  evidence. Guarded by regression tests that assert the production middleware chain omits `RealIP`
+  *and* that all three spoof headers leave `RemoteAddr` untouched, since a future chi bump won't
+  re-fix this. If qualify is ever fronted by a load balancer, parse `X-Forwarded-For` against a
+  configured trusted-proxy list — don't re-add `RealIP`. qualify is the suite's only chi consumer.
+
 ## [0.2.0] - 2026-07-21
 
 ### Security

--- a/cmd/qualify-agent/main.go
+++ b/cmd/qualify-agent/main.go
@@ -140,9 +140,17 @@ func main() {
 func (s *server) setupRouter() http.Handler {
 	r := chi.NewRouter()
 
-	// Middleware stack
+	// Middleware stack.
+	//
+	// Deliberately NO middleware.RealIP: it overwrites r.RemoteAddr with the
+	// leftmost X-Forwarded-For (or True-Client-IP / X-Real-IP) value whether or
+	// not a trusted proxy set it, so any client can forge the address we log
+	// (GHSA-3fxj-6jh8-hvhx / -rjr7-jggh-pgcp / -9g5q-2w5x-hmxf; chi deprecated it
+	// in v5.3.0 rather than fixing it). The agent binds loopback and sits behind
+	// no proxy, so r.RemoteAddr is already the true peer. If qualify ever runs
+	// behind a load balancer, parse X-Forwarded-For against a configured trusted
+	// -proxy list — don't re-add RealIP.
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
 	r.Use(loggerMiddleware)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Heartbeat("/ping"))

--- a/cmd/qualify-backend/main.go
+++ b/cmd/qualify-backend/main.go
@@ -163,9 +163,18 @@ func main() {
 func setupRouter(authCfg auth.Config, auditSvc *audit.Service, trainingSvc *training.Service) http.Handler {
 	r := chi.NewRouter()
 
-	// Middleware stack
+	// Middleware stack.
+	//
+	// Deliberately NO middleware.RealIP: it overwrites r.RemoteAddr with the
+	// leftmost X-Forwarded-For (or True-Client-IP / X-Real-IP) value whether or
+	// not a trusted proxy set it, so any client can forge the address we log
+	// (GHSA-3fxj-6jh8-hvhx / -rjr7-jggh-pgcp / -9g5q-2w5x-hmxf; chi deprecated it
+	// in v5.3.0 rather than fixing it). Without it r.RemoteAddr is the true TCP
+	// peer. This matters for a compliance tool: the request log is operator
+	// evidence, and a forgeable origin makes it unreliable. If qualify ever runs
+	// behind a load balancer, parse X-Forwarded-For against a configured trusted
+	// -proxy list — don't re-add RealIP.
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
 	r.Use(loggerMiddleware)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Heartbeat("/ping"))

--- a/cmd/qualify-backend/middleware_realip_test.go
+++ b/cmd/qualify-backend/middleware_realip_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/provabl/qualify/internal/auth"
+)
+
+// chi's middleware.RealIP is deprecated as unfixably spoofable: it rewrites
+// r.RemoteAddr from the leftmost X-Forwarded-For (or True-Client-IP /
+// X-Real-IP) value whether or not a trusted proxy set it
+// (GHSA-3fxj-6jh8-hvhx / -rjr7-jggh-pgcp / -9g5q-2w5x-hmxf). Because the
+// request log is operator evidence for a compliance tool, a forgeable origin
+// makes it unreliable. These tests guard the removal — bumping chi does NOT fix
+// this, so only keeping the middleware out does.
+
+// TestRouterOmitsRealIP inspects the real production middleware chain by
+// function pointer, so re-adding middleware.RealIP fails the build's tests even
+// if no request-level assertion happens to cover it.
+func TestRouterOmitsRealIP(t *testing.T) {
+	h := setupRouter(auth.Config{}, nil, nil)
+
+	mux, ok := h.(*chi.Mux)
+	if !ok {
+		t.Fatalf("setupRouter returned %T, expected *chi.Mux — update this test", h)
+	}
+
+	// Resolve each middleware to its function name rather than comparing against
+	// middleware.RealIP directly — naming the deprecated symbol would itself trip
+	// staticcheck's SA1019, and this keeps the repo free of any RealIP reference.
+	for i, mw := range mux.Middlewares() {
+		fn := runtime.FuncForPC(reflect.ValueOf(mw).Pointer())
+		if fn == nil {
+			continue
+		}
+		if strings.HasSuffix(fn.Name(), "middleware.RealIP") {
+			t.Errorf("middleware[%d] is chi middleware.RealIP: it lets any client forge "+
+				"r.RemoteAddr via X-Forwarded-For, corrupting the request log. To honor a "+
+				"proxy header, parse it against a configured trusted-proxy list instead.", i)
+		}
+	}
+}
+
+// TestForwardedForDoesNotOverrideRemoteAddr is the behavioral half: a request
+// carrying spoofed client-IP headers must reach the handler with r.RemoteAddr
+// still set to the true TCP peer.
+func TestForwardedForDoesNotOverrideRemoteAddr(t *testing.T) {
+	const truePeer = "192.0.2.10:54321"
+
+	var got string
+	mux := setupRouter(auth.Config{}, nil, nil).(*chi.Mux)
+	mux.Get("/__remote_addr_probe", func(_ http.ResponseWriter, r *http.Request) {
+		got = r.RemoteAddr
+	})
+
+	for _, hdr := range []string{"X-Forwarded-For", "X-Real-IP", "True-Client-IP"} {
+		t.Run(hdr, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/__remote_addr_probe", nil)
+			req.RemoteAddr = truePeer
+			req.Header.Set(hdr, "203.0.113.99")
+
+			mux.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got != truePeer {
+				t.Errorf("%s spoofed the logged client address: RemoteAddr = %q, want the true peer %q",
+					hdr, got, truePeer)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/aws/smithy-go v1.24.2
-	github.com/go-chi/chi/v5 v5.2.3
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
-github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
 github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=


### PR DESCRIPTION
Clears the three IP-spoofing advisories that turned qualify's weekly Security Scan red on 2026-07-27.

## The finding

`govulncheck` flagged **GO-2026-5774**, **GO-2026-5775**, **GO-2026-5777** — all in chi's `middleware.RealIP`, all symbol-reachable, since both `qualify-agent` and `qualify-backend` mounted it.

`RealIP` rewrites `r.RemoteAddr` from the leftmost `X-Forwarded-For` (or `True-Client-IP` / `X-Real-IP`) value **whether or not a trusted proxy set it** — so any client could forge the client address qualify logs.

## Why the version bump alone is not the fix

My first pass just bumped chi to v5.3.0 and `govulncheck` went green. The repo's own pre-commit `staticcheck` caught that as insufficient:

> `middleware.RealIP is deprecated: RealIP is vulnerable to IP spoofing ... (SA1019)`

**chi v5.3.0 deprecates `RealIP` rather than repairing it** — the design fundamentally can't distinguish a proxy-set header from a forged one. Upgrading only silences the scanner while leaving the hole open. So this PR **removes the middleware**; with it gone, `r.RemoteAddr` is the true TCP peer. Neither server sits behind a proxy, so nothing is lost. chi still moves to v5.3.0 to clear the advisory records and pick up the deprecation notice.

## Scope, stated precisely

This is a **log-integrity** fix, not an evidence-integrity one. I traced the spoofable value to the `slog` request line (`remote_addr`) — it does **not** reach the training audit record, because `audit.Entry.IPAddress` is currently never populated anywhere in the repo. It still matters for a compliance tool, whose request logs are operator evidence.

## Guard

A future chi bump will never re-fix this, so two regression tests lock the removal in:

1. `TestRouterOmitsRealIP` — asserts the **real production middleware chain** omits `RealIP`, matching on resolved function name so the repo keeps no deprecated reference and `staticcheck` stays clean.
2. `TestForwardedForDoesNotOverrideRemoteAddr` — asserts all three spoof headers leave `RemoteAddr` as the true peer.

Both were **verified to fail** when `RealIP` is re-added (`RemoteAddr = "203.0.113.99"`, want `"192.0.2.10:54321"`), so they're a real guard rather than a tautology.

If qualify is ever fronted by a load balancer, parse `X-Forwarded-For` against a configured trusted-proxy list — don't re-add `RealIP`. A comment at each call site says so.

## Verification

- `go build` / `go vet` / `staticcheck` / full `go test ./...` — all pass
- `govulncheck ./...` — **3 reachable vulnerabilities → 0**
- qualify is the suite's only chi consumer (checked all 10 repos)